### PR TITLE
Json spec

### DIFF
--- a/fastce/fastce.go
+++ b/fastce/fastce.go
@@ -1,7 +1,7 @@
 package fastce
 
 import (
-	// "encoding/json"
+	"time"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,6 +11,15 @@ import (
 
 	"github.com/valyala/fasthttp"
 )
+
+/*
+  ██████╗ ██████╗ ███╗   ██╗███████╗██╗   ██╗███╗   ███╗███████╗
+ ██╔════╝██╔═══██╗████╗  ██║██╔════╝██║   ██║████╗ ████║██╔════╝
+ ██║     ██║   ██║██╔██╗ ██║███████╗██║   ██║██╔████╔██║█████╗  
+ ██║     ██║   ██║██║╚██╗██║╚════██║██║   ██║██║╚██╔╝██║██╔══╝  
+ ╚██████╗╚██████╔╝██║ ╚████║███████║╚██████╔╝██║ ╚═╝ ██║███████╗
+  ╚═════╝ ╚═════╝ ╚═╝  ╚═══╝╚══════╝ ╚═════╝ ╚═╝     ╚═╝╚══════╝
+*/
 
 // GetEvents determines the mode and content type of a request and gets any event(s) from it
 func GetEvents(ctx *fasthttp.RequestCtx) (ces []j.CloudEvent, mode j.Mode, err error) {
@@ -45,16 +54,6 @@ func GetEvents(ctx *fasthttp.RequestCtx) (ces []j.CloudEvent, mode j.Mode, err e
 		err = fmt.Errorf("Unknown mode: %s", mode)
 	}
 	return
-}
-// CtxStructureJSONToCE converts a RequestCtx in Structured mode with JSON content type into a jsonce CloudEvent
-func CtxStructureJSONToCE(ctx *fasthttp.RequestCtx) (ce j.CloudEvent, err error) {
-	body := ctx.PostBody()
-	ce = j.CloudEvent{}
-	err = ce.UnmarshalJSON(body)
-	if err != nil {
-		return ce, fmt.Errorf("Could not unmarshal to event: %s", err.Error())
-	}
-	return ce, err
 }
 
 // CtxBinaryToCE converts a RequestCtx in Binary mode into a jsonce CloudEvent
@@ -94,6 +93,17 @@ func CtxBinaryToCE(ctx *fasthttp.RequestCtx) (ce j.CloudEvent, err error) {
 	return ce, err
 }
 
+// CtxStructureJSONToCE converts a RequestCtx in Structured mode with JSON content type into a jsonce CloudEvent
+func CtxStructureJSONToCE(ctx *fasthttp.RequestCtx) (ce j.CloudEvent, err error) {
+	body := ctx.PostBody()
+	ce = j.CloudEvent{}
+	err = ce.UnmarshalJSON(body)
+	if err != nil {
+		return ce, fmt.Errorf("Could not unmarshal to event: %s", err.Error())
+	}
+	return ce, err
+}
+
 // GetMode uses the Content Type header to determine the content mode of the request
 // https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#3-http-message-mapping
 func GetMode(ctx *fasthttp.RequestCtx) (mode j.Mode) {
@@ -107,6 +117,94 @@ func GetMode(ctx *fasthttp.RequestCtx) (mode j.Mode) {
 	}
 	return mode
 }
+
+/*
+ ██████╗ ██████╗  ██████╗ ██████╗ ██╗   ██╗ ██████╗███████╗
+ ██╔══██╗██╔══██╗██╔═══██╗██╔══██╗██║   ██║██╔════╝██╔════╝
+ ██████╔╝██████╔╝██║   ██║██║  ██║██║   ██║██║     █████╗  
+ ██╔═══╝ ██╔══██╗██║   ██║██║  ██║██║   ██║██║     ██╔══╝  
+ ██║     ██║  ██║╚██████╔╝██████╔╝╚██████╔╝╚██████╗███████╗
+ ╚═╝     ╚═╝  ╚═╝ ╚═════╝ ╚═════╝  ╚═════╝  ╚═════╝╚══════╝
+*/
+
+// PutEvents determines the mode and content type of a request and puts any event(s) into it
+// Note that ces[1...] are dropped unless mode is batch
+func PutEvents(ctx *fasthttp.RequestCtx, ces []j.CloudEvent, mode j.Mode) (err error) {
+	if len(ces) <1 {
+		return fmt.Errorf("Could not put %d events", len(ces))
+	}
+
+	// https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#13-content-modes
+	switch mode {
+	case j.ModeBinary:
+		err := CEToCtxBinary(ctx, ces[0])
+		if err !=nil {
+			return fmt.Errorf("Could not set binary event: %s", err.Error())
+		}
+		return nil
+	case j.ModeStructure:
+		ce := ces[0]
+		ct := ce.DataContentType
+		ctx.Response.Header.Set("Content-Type", ct)
+
+		if !strings.HasPrefix(ct, "application/cloudevents+json") {
+			return fmt.Errorf("Unknown event content media type: %s", ct)
+		}
+
+		err := CEToCtxStructureJSON(ctx, ce)
+		if err !=nil {
+			return fmt.Errorf("Could not set structure event: %s", err.Error())
+		}
+		return nil
+	case j.ModeBatch:
+		err = fmt.Errorf("Unimplemented mode: %s", mode)
+	default:
+		err = fmt.Errorf("Unknown mode: %s", mode)
+	}
+	return
+}
+
+// CEToCtxBinary converts a jsonce CloudEvent into a RequestCtx in Binary mode
+func CEToCtxBinary(ctx *fasthttp.RequestCtx, ce j.CloudEvent) (err error){	
+	// Required
+	ctx.Response.Header.Set("ce-id", ce.Id)
+	ctx.Response.Header.Set("ce-source", ce.Source)
+	ctx.Response.Header.Set("ce-specversion", ce.SpecVersion)
+	ctx.Response.Header.Set("ce-type", ce.Type)
+	// Optional
+	ctx.Response.Header.Set("Content-Type", ce.DataContentType)
+	ctx.Response.Header.Set("ce-dataschema", ce.DataSchema)
+	ctx.Response.Header.Set("ce-subject", ce.Subject)
+	ctx.Response.Header.Set("ce-time", ce.Time.Format(time.RFC3339Nano))
+	// Additional
+	ctx.Write(ce.Data)
+	for k, v := range ce.Extensions {
+		ctx.Response.Header.Set(fmt.Sprintf("ce-%s", k), fmt.Sprintf("%s", v))
+	}
+	return nil
+}
+
+// CEToCtxStructureJSON converts a jsonce CloudEvent into a RequestCtx in Structured mode with JSON content type
+func CEToCtxStructureJSON(ctx *fasthttp.RequestCtx, ce j.CloudEvent) (err error){
+	js, err := ce.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Could not marshal event: %s", err.Error())
+	}
+
+	ctx.Response.Header.Set("Content-Type", ce.DataContentType)
+	ctx.Write(js)
+
+	return nil
+}
+
+/*
+ ███████╗███████╗██████╗ ██╗   ██╗███████╗██████╗ 
+ ██╔════╝██╔════╝██╔══██╗██║   ██║██╔════╝██╔══██╗
+ ███████╗█████╗  ██████╔╝██║   ██║█████╗  ██████╔╝
+ ╚════██║██╔══╝  ██╔══██╗╚██╗ ██╔╝██╔══╝  ██╔══██╗
+ ███████║███████╗██║  ██║ ╚████╔╝ ███████╗██║  ██║
+ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝
+*/
 
 // ExampleServer shows an example implementation of each method with a fasthttp server.
 func ExampleServer(listenAddr string) {
@@ -122,61 +220,14 @@ func ExampleServer(listenAddr string) {
 					ctx.Error(err.Error(), http.StatusBadRequest)
 					return
 				} else {
-					log.Printf("OK : Received %s events in mode %s", len(ces), mode)
+					log.Printf("OK : Received %d events in mode %d\n", len(ces), mode)
 				}
 				fmt.Printf("\tData: %#v\n", ces)
-				ctx.Write([]byte(fmt.Sprintf("STUB:NO REPLY: %#v", ces)))
+				// ctx.Write([]byte(fmt.Sprintf("STUB:NO REPLY: %#v", ces)))
+				PutEvents(ctx, ces, mode)
 		}
 	}
 	if err := fasthttp.ListenAndServe(listenAddr, router); err != nil {
 		log.Fatalf("Error in ListenAndServe: %s", err)
-	}
-}
-
-// // EventToFastHTTPStructured sets the given headers and body on the given fasthttp response in structured mode.
-// func EventToFastHTTPStructured(event j.CloudEvent) func(*fasthttp.RequestCtx)error {
-// 	return func(ctx *fasthttp.RequestCtx) (err error) {
-// 		ctx.Response.Header.Set("Content-Type", event.Datacontenttype)
-// 	/*
-// 		jsonEvent := map[string][]byte{}
-// 		jsonEvent["type"] = []byte(event.Type)
-// 		jsonEvent["time"] = []byte(event.Time.Format(time.RFC3339))
-// 		jsonEvent["id"] = []byte(event.Id)
-// 		jsonEvent["source"] = []byte(event.Source)
-// 		jsonEvent["specversion"] = []byte(event.Specversion)
-// 		for k, v := range event.Extensions {
-// 			jsonEvent[k] = []byte(v)
-// 		}
-// 		jsonEvent["data"] = []byte(event.Data)
-// 	*/	js, err := json.Marshal(event)
-// 		if err != nil {
-// 			err = fmt.Errorf("Could not marshal: %s", err.Error())
-// 			return
-// 		}
-// 		ctx.Write(js)
-// 		return
-// 	}
-// }
-
-// EventToFastHTTPBinary sets the given headers and body on the given fasthttp response in binary mode.
-func EventToFastHTTPBinary(event j.CloudEvent) func(*fasthttp.RequestCtx)error {
-	return func(ctx *fasthttp.RequestCtx) (err error) {
-		ctx.Response.Header.Set("Content-Type", event.Datacontenttype)
-		ctx.Response.Header.Set("ce-type", event.Type)
-		ctx.Response.Header.Set("ce-time", event.Time.Format(time.RFC3339Nano))
-		ctx.Response.Header.Set("ce-id", event.Id)
-		ctx.Response.Header.Set("ce-source", event.Source)
-		ctx.Response.Header.Set("ce-specversion", event.Specversion)
-		ctx.Write(event.Data)
-		ExtensionsToFastHTTPBinary(ctx, event.Extensions)
-		return
-	}
-}
-
-
-// ExtensionsToFastHTTPBinary sets the given extension headers on the given fasthttp response in binary mode.
-func ExtensionsToFastHTTPBinary(ctx *fasthttp.RequestCtx, extensions map[string]json.RawMessage) {
-	for k, v := range extensions {
-		ctx.Response.Header.Set(fmt.Sprintf("ce-%s", k), string(v))
 	}
 }

--- a/fastce/fastce.go
+++ b/fastce/fastce.go
@@ -2,8 +2,6 @@ package fastce
 
 import (
 	"fmt"
-	"log"
-	"net/http"
 	"strings"
 	"time"
 
@@ -193,39 +191,4 @@ func CEToCtxStructureJSON(ctx *fasthttp.RequestCtx, ce j.CloudEvent) (err error)
 	ctx.Response.Header.Set("Content-Type", ce.DataContentType)
 
 	return nil
-}
-
-/*
- ███████╗███████╗██████╗ ██╗   ██╗███████╗██████╗
- ██╔════╝██╔════╝██╔══██╗██║   ██║██╔════╝██╔══██╗
- ███████╗█████╗  ██████╔╝██║   ██║█████╗  ██████╔╝
- ╚════██║██╔══╝  ██╔══██╗╚██╗ ██╔╝██╔══╝  ██╔══██╗
- ███████║███████╗██║  ██║ ╚████╔╝ ███████╗██║  ██║
- ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝
-*/
-
-// ExampleServer shows an example implementation of each method with a fasthttp server.
-func ExampleServer(listenAddr string) {
-	router := func(ctx *fasthttp.RequestCtx) {
-		switch p := string(ctx.Path()); p {
-		case "/debug":
-			ctx.Write([]byte("Hello World"))
-			break
-		default:
-			ces, mode, err := GetEvents(ctx)
-			if err != nil {
-				log.Printf("ERR: %s", err.Error())
-				ctx.Error(err.Error(), http.StatusBadRequest)
-				return
-			} else {
-				log.Printf("OK : Received %d events in mode %d\n", len(ces), mode)
-			}
-			fmt.Printf("\tData: %#v\n", ces)
-			// ctx.Write([]byte(fmt.Sprintf("STUB:NO REPLY: %#v", ces)))
-			PutEvents(ctx, ces, mode)
-		}
-	}
-	if err := fasthttp.ListenAndServe(listenAddr, router); err != nil {
-		log.Fatalf("Error in ListenAndServe: %s", err)
-	}
 }

--- a/fastce/fastce.go
+++ b/fastce/fastce.go
@@ -1,132 +1,182 @@
 package fastce
 
 import (
-	"encoding/json"
-	"errors"
+	// "encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
-	"time"
+
+	j "github.com/creativecactus/fast-cloudevents-go/jsonce"
 
 	"github.com/valyala/fasthttp"
 )
 
-// CloudEvent represents a stored cloud event in memory.
-type CloudEvent struct {
-	Datacontenttype string            `json:"datacontenttype"`
-	Type            string            `json:"type"`
-	Time            time.Time         `json:"time"`
-	Id              string            `json:"id"`
-	Source          string            `json:"source"`
-	Specversion     string            `json:"specversion"`
-	Data            []byte            `json:"data"`
-	Extensions      map[string]string `json:"extensions"`
+// GetEvents determines the mode and content type of a request and gets any event(s) from it
+func GetEvents(ctx *fasthttp.RequestCtx) (ces []j.CloudEvent, mode j.Mode, err error) {
+	// https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#13-content-modes
+	mode = GetMode(ctx)
+	switch mode {
+	case j.ModeBinary:
+		ce, err := CtxBinaryToCE(ctx)
+		if err !=nil {
+			return ces, mode, fmt.Errorf("Could not get binary event: %s", err.Error())
+		}
+		ces = append(ces, ce)
+		return ces, mode, nil
+	case j.ModeStructure:
+		// Determine the media type with which to parse the event
+		// Or reject anything other than JSON
+		// https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#3-http-message-mapping
+		ct := string(ctx.Request.Header.Peek("Content-Type"))
+		if !strings.HasPrefix(ct, "application/cloudevents+json") {
+			return ces, mode, fmt.Errorf("Unknown event content media type: %s", ct)
+		}
+
+		ce, err := CtxStructureJSONToCE(ctx)
+		if err !=nil {
+			return ces, mode, fmt.Errorf("Could not get structure event: %s", err.Error())
+		}
+		ces = append(ces, ce)
+		return ces, mode, nil
+	case j.ModeBatch:
+		err = fmt.Errorf("Unimplemented mode: %s", mode)
+	default:
+		err = fmt.Errorf("Unknown mode: %s", mode)
+	}
+	return
+}
+// CtxStructureJSONToCE converts a RequestCtx in Structured mode with JSON content type into a jsonce CloudEvent
+func CtxStructureJSONToCE(ctx *fasthttp.RequestCtx) (ce j.CloudEvent, err error) {
+	body := ctx.PostBody()
+	ce = j.CloudEvent{}
+	err = ce.UnmarshalJSON(body)
+	if err != nil {
+		return ce, fmt.Errorf("Could not unmarshal to event: %s", err.Error())
+	}
+	return ce, err
+}
+
+// CtxBinaryToCE converts a RequestCtx in Binary mode into a jsonce CloudEvent
+func CtxBinaryToCE(ctx *fasthttp.RequestCtx) (ce j.CloudEvent, err error) {
+	m := map[string]interface{}{}
+
+	// Required
+	m["id"] = string(ctx.Request.Header.Peek("ce-id"))
+	m["source"] = string(ctx.Request.Header.Peek("ce-source"))
+	m["specversion"] = string(ctx.Request.Header.Peek("ce-specversion"))
+	m["type"] = string(ctx.Request.Header.Peek("ce-type"))
+
+	// Optional
+	m["datacontenttype"] = string(ctx.Request.Header.Peek("Content-Type"))
+	m["dataschema"] = string(ctx.Request.Header.Peek("ce-dataschema"))
+	m["subject"] = string(ctx.Request.Header.Peek("ce-subject"))
+	m["time"] = string(ctx.Request.Header.Peek("ce-time"))
+
+	// Additional
+	j.SetData(m, ctx.PostBody())
+
+	head := map[string]interface{}{}
+	ctx.Request.Header.VisitAll(func(k, v []byte) {
+		if !strings.HasPrefix(string(k),"ce-") {
+			return
+		}
+		key := strings.TrimPrefix(string(k), "ce-")
+		if j.InSlice(key, j.ContextProperties) {
+			return
+		}
+		head[key] = v
+	})
+	m["extensions"] = head //FastHTTPToExtensionsBinary(ctx),
+
+	ce = j.CloudEvent{}
+	err = ce.FromMap(m)
+	return ce, err
+}
+
+// GetMode uses the Content Type header to determine the content mode of the request
+// https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md#3-http-message-mapping
+func GetMode(ctx *fasthttp.RequestCtx) (mode j.Mode) {
+	ct := string(ctx.Request.Header.Peek("Content-Type"))
+
+	mode = j.ModeBinary
+	if strings.HasPrefix(ct, "application/cloudevents-batch") {
+		mode = j.ModeBatch
+	} else if strings.HasPrefix(ct, "application/cloudevents") {
+		mode = j.ModeStructure
+	}
+	return mode
 }
 
 // ExampleServer shows an example implementation of each method with a fasthttp server.
-func ExampleServer() {
-	listenAddr := "0.0.0.0:8080"
-	requestHandler := func(ctx *fasthttp.RequestCtx) {
-		event, err := FastHTTPToEventBinary(ctx)
-		if err != nil {
-			ctx.Error(err.Error(), http.StatusBadRequest)
-			return
+func ExampleServer(listenAddr string) {
+	router := func(ctx *fasthttp.RequestCtx) {
+		switch p := string(ctx.Path()); p {
+			case "/debug":
+				ctx.Write([]byte("Hello World"))
+				break
+			default:
+				ces, mode, err := GetEvents(ctx)
+				if err != nil {
+					log.Printf("ERR: %s", err.Error())
+					ctx.Error(err.Error(), http.StatusBadRequest)
+					return
+				} else {
+					log.Printf("OK : Received %s events in mode %s", len(ces), mode)
+				}
+				fmt.Printf("\tData: %#v\n", ces)
+				ctx.Write([]byte(fmt.Sprintf("STUB:NO REPLY: %#v", ces)))
 		}
-		js, err := json.Marshal(event)
-		if err != nil {
-			ctx.Error("Could not marshal", http.StatusInternalServerError)
-			return
-		}
-		log.Printf("%s\n", string(js))
-		if err = json.Unmarshal(js, &event); err != nil {
-			ctx.Error("Could not unmarshal", http.StatusInternalServerError)
-			return
-		}
-		EventToFastHTTPBinary(event)(ctx) //fmt.Fprintf(ctx, "%q", ctx.Path())
 	}
-	if err := fasthttp.ListenAndServe(listenAddr, requestHandler); err != nil {
+	if err := fasthttp.ListenAndServe(listenAddr, router); err != nil {
 		log.Fatalf("Error in ListenAndServe: %s", err)
 	}
 }
 
-// FastHTTPToEventBinary returns an event from the given fasthttp request in binary mode.
-func FastHTTPToEventBinary(ctx *fasthttp.RequestCtx) (ce CloudEvent, err error) {
-	time, err := time.Parse(
-		time.RFC3339,
-		string(ctx.Request.Header.Peek("ce-time")))
-	if err != nil {
-		err = errors.New("Invalid RFC3339 time")
-		return
-	}
-	ce = CloudEvent{
-		Datacontenttype: string(ctx.Request.Header.Peek("Content-Type")),
-		Type:            string(ctx.Request.Header.Peek("ce-type")),
-		Time:            time,
-		Id:              string(ctx.Request.Header.Peek("ce-id")),
-		Source:          string(ctx.Request.Header.Peek("ce-source")),
-		Specversion:     string(ctx.Request.Header.Peek("ce-specversion")),
-		Data:            ctx.PostBody(),
-		Extensions:      FastHTTPToExtensionsBinary(ctx),
-	}
-	return
-}
+// // EventToFastHTTPStructured sets the given headers and body on the given fasthttp response in structured mode.
+// func EventToFastHTTPStructured(event j.CloudEvent) func(*fasthttp.RequestCtx)error {
+// 	return func(ctx *fasthttp.RequestCtx) (err error) {
+// 		ctx.Response.Header.Set("Content-Type", event.Datacontenttype)
+// 	/*
+// 		jsonEvent := map[string][]byte{}
+// 		jsonEvent["type"] = []byte(event.Type)
+// 		jsonEvent["time"] = []byte(event.Time.Format(time.RFC3339))
+// 		jsonEvent["id"] = []byte(event.Id)
+// 		jsonEvent["source"] = []byte(event.Source)
+// 		jsonEvent["specversion"] = []byte(event.Specversion)
+// 		for k, v := range event.Extensions {
+// 			jsonEvent[k] = []byte(v)
+// 		}
+// 		jsonEvent["data"] = []byte(event.Data)
+// 	*/	js, err := json.Marshal(event)
+// 		if err != nil {
+// 			err = fmt.Errorf("Could not marshal: %s", err.Error())
+// 			return
+// 		}
+// 		ctx.Write(js)
+// 		return
+// 	}
+// }
 
 // EventToFastHTTPBinary sets the given headers and body on the given fasthttp response in binary mode.
-func EventToFastHTTPBinary(event CloudEvent) func(*fasthttp.RequestCtx) {
-	return func(ctx *fasthttp.RequestCtx) {
+func EventToFastHTTPBinary(event j.CloudEvent) func(*fasthttp.RequestCtx)error {
+	return func(ctx *fasthttp.RequestCtx) (err error) {
 		ctx.Response.Header.Set("Content-Type", event.Datacontenttype)
 		ctx.Response.Header.Set("ce-type", event.Type)
-		ctx.Response.Header.Set("ce-time", event.Time.Format(time.RFC3339))
+		ctx.Response.Header.Set("ce-time", event.Time.Format(time.RFC3339Nano))
 		ctx.Response.Header.Set("ce-id", event.Id)
 		ctx.Response.Header.Set("ce-source", event.Source)
 		ctx.Response.Header.Set("ce-specversion", event.Specversion)
 		ctx.Write(event.Data)
 		ExtensionsToFastHTTPBinary(ctx, event.Extensions)
+		return
 	}
 }
 
-// FastHTTPToExtensionsBinary returns a map of ce- prefixed extensions from the given fasthttp request in binary mode.
-func FastHTTPToExtensionsBinary(ctx *fasthttp.RequestCtx) map[string]string {
-	head := map[string]string{}
-	ctx.Request.Header.VisitAll(func(key, value []byte) {
-		if KnownHeader(string(key)) {
-			return
-		}
-		if valid, name := ExtendedHeader(string(key)); valid {
-			head[name] = string(value)
-		}
-	})
-	return head
-}
 
 // ExtensionsToFastHTTPBinary sets the given extension headers on the given fasthttp response in binary mode.
-func ExtensionsToFastHTTPBinary(ctx *fasthttp.RequestCtx, extensions map[string]string) {
+func ExtensionsToFastHTTPBinary(ctx *fasthttp.RequestCtx, extensions map[string]json.RawMessage) {
 	for k, v := range extensions {
-		ctx.Response.Header.Set(fmt.Sprintf("ce-%s", k), v)
+		ctx.Response.Header.Set(fmt.Sprintf("ce-%s", k), string(v))
 	}
-}
-
-// ExtendedHeader returns true and the unprefixed name of a string if it is an extension header key.
-func ExtendedHeader(h string) (bool, string) {
-	parts := strings.SplitN(strings.ToLower(h), "ce-", 2)
-	num := len(parts)
-	return num >= 2, parts[num-1]
-}
-
-// KnownHeader returns true when the given string is a known, ce- prefixed header key.
-func KnownHeader(h string) bool {
-	known := []string{
-		"ce-type",
-		"ce-time",
-		"ce-id",
-		"ce-source",
-		"ce-specversion",
-	}
-	for _, kh := range known {
-		if kh == strings.ToLower(h) {
-			return true
-		}
-	}
-	return false
 }

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -1,51 +1,10 @@
-package main // jsonce
+package jsonce
 
 import (
 	"encoding/json"
 	"fmt"
 	"time"
 )
-
-// main is used as a test until this branch can merge to v1
-func main() {
-	ce := CloudEvent{
-		Id:          "test",
-		Source:      "test",
-		SpecVersion: "test",
-		Type:        "test",
-		Data:        []byte(`{"a":2}`),
-	}
-	fmt.Println("Literal:")
-	fmt.Printf("	%#v\n", ce)
-	fmt.Println("Marshal:")
-	b, e := ce.MarshalJSON()
-	fmt.Printf("	json:%s\n	err:%+v\n", b, e)
-
-	fmt.Println("Unmarshal:")
-	ce = CloudEvent{}
-	data := `{}`
-	if err := ce.UnmarshalJSON([]byte(data)); err != nil {
-		fmt.Printf("	err: %s\n", err.Error())
-	}
-	fmt.Printf("	%#v\n", ce)
-
-	fmt.Println("Generic:")
-
-	type G struct {
-		Data json.RawMessage `json:"data"`
-	}
-	g := G{}
-	m := map[string]interface{}{}
-	if err := json.Unmarshal(b, &g); err != nil {
-		fmt.Printf("Could not unmarshal event data: %s\n", err.Error())
-	}
-	if err := json.Unmarshal(b, &m); err != nil {
-		fmt.Printf("Could not unmarshal event: %s\n", err.Error())
-	}
-	m["data"] = g.Data
-	err := ce.FromMap(m)
-	fmt.Printf("	err:%#v\n	json:%#v\n", err, ce)
-}
 
 // CloudEvent is the primary format for events
 // https://github.com/cloudevents/spec/blob/master/spec.md

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -1,0 +1,220 @@
+package main // jsonce
+
+import (
+	"encoding/json"
+        "fmt"
+        "time"
+)
+
+func main(){
+	ce := CloudEvent{
+		Id: "test",
+		Source: "test",
+		SpecVersion: "test",
+		Type: "test",
+		Data: []byte(`{"a":2}`),
+	}
+	fmt.Printf("	%#v\n", ce)
+	b, e := ce.MarshalJSON()
+	fmt.Printf("	json:%s\n	err:%+v\n", b, e)
+
+
+
+	ce.From
+	fmt.Printf("	%#v\n", ce)
+
+
+}
+
+// https://github.com/cloudevents/spec/blob/master/spec.md
+type CloudEvent struct {
+	// Required
+	Id string
+	Source string // URI-reference
+	SpecVersion string
+	Type string
+
+	// Optional
+	DataContentType string // RFC 2046
+	DataSchema string // URI
+	Subject string
+	Time time.Time // RFC3339
+
+	// Additional
+	Extensions map[string]json.RawMessage
+	Data []byte //json.RawMessage // Internal, use .GetData()
+	//Data64 []byte // Internal, use .GetData()
+}
+
+func (ce CloudEvent) Valid() bool {
+	// If extensions contains a Context Attribute name, that's bad
+	// If the data does not seem to be compatible with the contenttype
+	// If URI fields are out of spec
+	return true
+}
+
+func (ce CloudEvent) UnmarshalJSON(data []byte) (err error) {
+    m = map[string]interface{}{}
+    if err = json.Unmarshal(data, &m); err != nil {
+	return fmt.Errorf("Could not unmarshal event: %s", err.Error())
+    }
+    ce.FromMap(m)
+    return
+}
+func (ce CloudEvent) MarshalJSON() ([]byte, error) {
+    return json.Marshal(ce.ToMap())
+}
+func (ce CloudEvent) ToMap() (m map[string]interface{}) {
+    // Required
+    m = map[string]interface{}{}
+    m["id"] = ce.Id
+    m["source"] = ce.Source
+    m["specversion"] = ce.SpecVersion
+    m["type"] = ce.Type
+
+    // Optional
+    if len(ce.DataContentType)>0 {
+        m["datacontenttype"] = ce.DataContentType
+    }
+    if len(ce.DataSchema)>0 {
+        m["dataschema"] = ce.DataSchema
+    }
+    if len(ce.Subject)>0 {
+        m["subject"] = ce.Subject
+    }
+    if !ce.Time.IsZero() {
+        m["time"] = ce.Time.Format(time.RFC3339)
+    }
+
+    // Additional
+    for k, v := range ce.Extensions {
+	m[k] = v
+    }
+
+    if len(ce.Data)>0 {
+	// https://github.com/cloudevents/spec/blob/v1.0/json-format.md#31-handling-of-data
+	if js, err := RawJSON(ce.Data); err == nil {
+		m["data"] = js
+	} else {
+		m["data_base64"] = ce.Data
+	}
+    }
+
+    return
+}
+
+func RawJSON(data []byte) (js json.RawMessage, err error) {
+    return js, json.Unmarshal(data, &js)
+}
+func (ce *CloudEvent) FromMap (m map[string]interface{}) (err error) {
+	// Required
+	ok := false
+	if ce.Id, ok = m["id"].(string); !ok {
+		return fmt.Errorf("Could not read ID as string")
+	}
+	if ce.Source, ok = m["source"].(string); !ok {
+		return fmt.Errorf("Could not read Source as string")
+	}
+	if ce.SpecVersion, ok = m["specversion"].(string); !ok {
+		return fmt.Errorf("Could not read Spec Version as string")
+	}
+	if ce.Type, ok = m["type"].(string); !ok {
+		return fmt.Errorf("Could not read Type as string")
+	}
+
+	// Optional
+	if m["datacontenttype"] != nil {
+		if ce.DataContentType, ok = m["datacontenttype"].(string); !ok {
+			return fmt.Errorf("Could not read Data Content Type as string")
+		}
+	}
+	if m["dataschema"] != nil {
+		if ce.DataSchema, ok = m["dataschema"].(string); !ok {
+			return fmt.Errorf("Could not read Data Schema as string")
+		}
+	}
+	if m["subject"] != nil {
+		if ce.DataSchema, ok = m["subject"].(string); !ok {
+			return fmt.Errorf("Could not read Subject as string")
+		}
+	}
+	if m["time"] != nil {
+		ceTime, ok := m["time"].(string)
+		if !ok {
+			return fmt.Errorf("Could not read Time as string")
+		}
+		ce.Time, err = time.Parse(
+			time.RFC3339,//Nano
+			ceTime)
+		if err != nil {
+			return fmt.Errorf("Could not read Time as time: %s", err.Error())
+		}
+	}
+
+
+	// Additional
+	ex, err := GetMapExtensions(m)
+	if err != nil {
+		return fmt.Errorf("Could not read Extensions: %s", err.Error())
+	}
+	if len(ex)>0 {
+		ce.Extensions = ex
+	}
+
+	if m["data_base64"] != nil {
+		if ce.Data, ok = m["data_base64"].([]byte) ; !ok {
+			return fmt.Errorf("Could not read Data Base64 as []byte")
+		}
+	} else if m["data"] != nil {
+		mData, ok := m["data"].([]byte)
+		if !ok {
+			return fmt.Errorf("Could not read Data as string")
+		}
+		ceData, err := RawJSON(mData)
+		if err != nil {
+			return fmt.Errorf("Could not read Data as json: %s", err.Error())
+		}
+		ce.Data = ceData
+	}
+
+	return nil
+}
+
+
+var contextProperties = []string{
+	"id",
+	"source",
+	"specversion",
+	"type",
+	"datacontenttype",
+	"dataschema",
+	"subject",
+	"time",
+	"data",
+}
+func GetMapExtensions(m map[string]interface{}) (ex map[string]json.RawMessage, err error){
+	for k, v := range m {
+		if inSlice(k, contextProperties) {
+			continue;
+		}
+		raw, ok := v.([]byte)
+		if !ok {
+			return ex, fmt.Errorf("Could not read extension %s", k)
+		}
+		data, err := RawJSON(raw)
+		if err != nil {
+			return ex, fmt.Errorf("Could not parse extension %s: %s", k, err.Error())
+		}
+		ex[k] = data
+	}
+	return
+}
+func inSlice(e string, list []string) bool {
+    for _, v := range list {
+        if v == e {
+            return true
+        }
+    }
+    return false
+}
+

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
 )
 
 // main is used as a test until this branch can merge to v1
@@ -30,10 +29,9 @@ func main() {
 	}
 	fmt.Printf("	%#v\n", ce)
 
-
 	fmt.Println("Generic:")
 
-	type G struct{
+	type G struct {
 		Data json.RawMessage `json:"data"`
 	}
 	g := G{}
@@ -46,7 +44,7 @@ func main() {
 	}
 	m["data"] = g.Data
 	err := ce.FromMap(m)
-	fmt.Printf("	err:%#v\n	json:%#v\n",err, ce)
+	fmt.Printf("	err:%#v\n	json:%#v\n", err, ce)
 }
 
 // CloudEvent is the primary format for events
@@ -84,9 +82,9 @@ func (ce CloudEvent) Valid() bool {
 // UnmarshalJSON allows translation of []byte to CloudEvent
 func (ce *CloudEvent) UnmarshalJSON(data []byte) (err error) {
 	m := map[string]interface{}{}
-	g := struct{
-		Data json.RawMessage `json:"data"`
-		Data64 []byte `json:"data_base64"`
+	g := struct {
+		Data   json.RawMessage `json:"data"`
+		Data64 []byte          `json:"data_base64"`
 	}{}
 	if err = json.Unmarshal(data, &m); err != nil {
 		return fmt.Errorf("Could not unmarshal event: %s", err.Error())
@@ -94,18 +92,20 @@ func (ce *CloudEvent) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, &g); err != nil {
 		return fmt.Errorf("Could not unmarshal event data: %s", err.Error())
 	}
-	if len(g.Data) >0 {
+	if len(g.Data) > 0 {
 		m["data"] = g.Data
 	}
-	if len(g.Data64) >0 {
+	if len(g.Data64) > 0 {
 		m["data_base64"] = g.Data64
 	}
 	return ce.FromMap(m)
 }
+
 // MarshalJSON allows translation of CloudEvent to []byte
 func (ce CloudEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ce.ToMap())
 }
+
 // ToMap produces an intermediate representation of a CloudEvent
 func (ce CloudEvent) ToMap() (m map[string]interface{}) {
 	// Required
@@ -145,49 +145,50 @@ func (ce CloudEvent) ToMap() (m map[string]interface{}) {
 
 	return
 }
+
 // FromMap converts the intermediate map representation back into a CloudEvent
 func (ce *CloudEvent) FromMap(m map[string]interface{}) (err error) {
 	// Required https://github.com/cloudevents/spec/blob/master/spec.md#required-attributes
 	ok := false
-	if ce.Id, ok = m["id"].(string); !ok || len(ce.Id) <1 {
+	if ce.Id, ok = m["id"].(string); !ok || len(ce.Id) < 1 {
 		return fmt.Errorf(errRead("ID", "nonempty string"))
 	}
-	if ce.Source, ok = m["source"].(string); !ok || len(ce.Source) <1 {
+	if ce.Source, ok = m["source"].(string); !ok || len(ce.Source) < 1 {
 		return fmt.Errorf(errRead("Source", "nonempty string"))
 	}
-	if ce.SpecVersion, ok = m["specversion"].(string); !ok || len(ce.Source) <1 {
+	if ce.SpecVersion, ok = m["specversion"].(string); !ok || len(ce.Source) < 1 {
 		return fmt.Errorf(errRead("Spec Version", "nonempty string"))
 	}
-	if ce.Type, ok = m["type"].(string); !ok || len(ce.Type) <1 {
+	if ce.Type, ok = m["type"].(string); !ok || len(ce.Type) < 1 {
 		return fmt.Errorf(errRead("Type", "nonempty string"))
 	}
 
 	// Optional
 	if m["datacontenttype"] != nil {
 		if ce.DataContentType, ok = m["datacontenttype"].(string); !ok {
-			return fmt.Errorf(errRead("Data Content Type","string"))
+			return fmt.Errorf(errRead("Data Content Type", "string"))
 		}
 	}
 	if m["dataschema"] != nil {
 		if ce.DataSchema, ok = m["dataschema"].(string); !ok {
-			return fmt.Errorf(errRead("Data Schema","string"))
+			return fmt.Errorf(errRead("Data Schema", "string"))
 		}
 	}
 	if m["subject"] != nil {
 		if ce.DataSchema, ok = m["subject"].(string); !ok {
-			return fmt.Errorf(errRead("Subject","string"))
+			return fmt.Errorf(errRead("Subject", "string"))
 		}
 	}
 	if m["time"] != nil {
 		ceTime, ok := m["time"].(string)
 		if !ok {
-			return fmt.Errorf(errRead("Time","string"))
+			return fmt.Errorf(errRead("Time", "string"))
 		}
 		ce.Time, err = time.Parse(
 			time.RFC3339, // allows Nano - see tests
 			ceTime)
 		if err != nil {
-			return fmt.Errorf("%s: %s", errRead("Time","time"), err.Error())
+			return fmt.Errorf("%s: %s", errRead("Time", "time"), err.Error())
 		}
 	}
 	// Additional
@@ -201,19 +202,19 @@ func (ce *CloudEvent) FromMap(m map[string]interface{}) (err error) {
 
 	if m["data_base64"] != nil {
 		if ce.Data, ok = m["data_base64"].([]byte); !ok {
-			return fmt.Errorf(errRead("Data Base64","[]byte"))
+			return fmt.Errorf(errRead("Data Base64", "[]byte"))
 		}
 	} else if m["data"] != nil {
 		mData, ok := m["data"].(json.RawMessage)
 		if !ok {
-			return fmt.Errorf(errRead("Data","string"))
+			return fmt.Errorf(errRead("Data", "string"))
 		}
-		if len(mData) <1 {
+		if len(mData) < 1 {
 			return nil
 		}
 		ceData, err := rawJSON([]byte(mData))
 		if err != nil {
-			return fmt.Errorf("%s: %s", errRead("Data","json"), err.Error())
+			return fmt.Errorf("%s: %s", errRead("Data", "json"), err.Error())
 		}
 		ce.Data = ceData
 	}

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -2,177 +2,215 @@ package main // jsonce
 
 import (
 	"encoding/json"
-        "fmt"
-        "time"
+	"fmt"
+	"time"
+
 )
 
-func main(){
+// main is used as a test until this branch can merge to v1
+func main() {
 	ce := CloudEvent{
-		Id: "test",
-		Source: "test",
+		Id:          "test",
+		Source:      "test",
 		SpecVersion: "test",
-		Type: "test",
-		Data: []byte(`{"a":2}`),
+		Type:        "test",
+		Data:        []byte(`{"a":2}`),
 	}
+	fmt.Println("Literal:")
 	fmt.Printf("	%#v\n", ce)
+	fmt.Println("Marshal:")
 	b, e := ce.MarshalJSON()
 	fmt.Printf("	json:%s\n	err:%+v\n", b, e)
 
-
-
-	ce.From
+	fmt.Println("Unmarshal:")
+	ce = CloudEvent{}
+	data := `{}`
+	if err := ce.UnmarshalJSON([]byte(data)); err != nil {
+		fmt.Printf("	err: %s\n", err.Error())
+	}
 	fmt.Printf("	%#v\n", ce)
 
 
+	fmt.Println("Generic:")
+
+	type G struct{
+		Data json.RawMessage `json:"data"`
+	}
+	g := G{}
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(b, &g); err != nil {
+		fmt.Printf("Could not unmarshal event data: %s\n", err.Error())
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		fmt.Printf("Could not unmarshal event: %s\n", err.Error())
+	}
+	m["data"] = g.Data
+	err := ce.FromMap(m)
+	fmt.Printf("	err:%#v\n	json:%#v\n",err, ce)
 }
 
+// CloudEvent is the primary format for events
 // https://github.com/cloudevents/spec/blob/master/spec.md
 type CloudEvent struct {
 	// Required
-	Id string
-	Source string // URI-reference
+	Id          string
+	Source      string // URI-reference
 	SpecVersion string
-	Type string
+	Type        string
 
 	// Optional
 	DataContentType string // RFC 2046
-	DataSchema string // URI
-	Subject string
-	Time time.Time // RFC3339
+	DataSchema      string // URI
+	Subject         string
+	Time            time.Time // RFC3339
 
 	// Additional
 	Extensions map[string]json.RawMessage
-	Data []byte //json.RawMessage // Internal, use .GetData()
-	//Data64 []byte // Internal, use .GetData()
+	Data       []byte
 }
 
+// Valid returns true if the CloudEvent seems to fit the spec
 func (ce CloudEvent) Valid() bool {
+	panic("Stubbed function")
 	// If extensions contains a Context Attribute name, that's bad
 	// If the data does not seem to be compatible with the contenttype
 	// If URI fields are out of spec
 	return true
 }
 
-func (ce CloudEvent) UnmarshalJSON(data []byte) (err error) {
-    m = map[string]interface{}{}
-    if err = json.Unmarshal(data, &m); err != nil {
-	return fmt.Errorf("Could not unmarshal event: %s", err.Error())
-    }
-    ce.FromMap(m)
-    return
+// UnmarshalJSON allows translation of []byte to CloudEvent
+func (ce *CloudEvent) UnmarshalJSON(data []byte) (err error) {
+	m := map[string]interface{}{}
+	g := struct{
+		Data json.RawMessage `json:"data"`
+		Data64 []byte `json:"data_base64"`
+	}{}
+	if err = json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("Could not unmarshal event: %s", err.Error())
+	}
+	if err = json.Unmarshal(data, &g); err != nil {
+		return fmt.Errorf("Could not unmarshal event data: %s", err.Error())
+	}
+	if len(g.Data) >0 {
+		m["data"] = g.Data
+	}
+	if len(g.Data64) >0 {
+		m["data_base64"] = g.Data64
+	}
+	return ce.FromMap(m)
 }
+// MarshalJSON allows translation of CloudEvent to []byte
 func (ce CloudEvent) MarshalJSON() ([]byte, error) {
-    return json.Marshal(ce.ToMap())
+	return json.Marshal(ce.ToMap())
 }
+// ToMap produces an intermediate representation of a CloudEvent
 func (ce CloudEvent) ToMap() (m map[string]interface{}) {
-    // Required
-    m = map[string]interface{}{}
-    m["id"] = ce.Id
-    m["source"] = ce.Source
-    m["specversion"] = ce.SpecVersion
-    m["type"] = ce.Type
-
-    // Optional
-    if len(ce.DataContentType)>0 {
-        m["datacontenttype"] = ce.DataContentType
-    }
-    if len(ce.DataSchema)>0 {
-        m["dataschema"] = ce.DataSchema
-    }
-    if len(ce.Subject)>0 {
-        m["subject"] = ce.Subject
-    }
-    if !ce.Time.IsZero() {
-        m["time"] = ce.Time.Format(time.RFC3339)
-    }
-
-    // Additional
-    for k, v := range ce.Extensions {
-	m[k] = v
-    }
-
-    if len(ce.Data)>0 {
-	// https://github.com/cloudevents/spec/blob/v1.0/json-format.md#31-handling-of-data
-	if js, err := RawJSON(ce.Data); err == nil {
-		m["data"] = js
-	} else {
-		m["data_base64"] = ce.Data
-	}
-    }
-
-    return
-}
-
-func RawJSON(data []byte) (js json.RawMessage, err error) {
-    return js, json.Unmarshal(data, &js)
-}
-func (ce *CloudEvent) FromMap (m map[string]interface{}) (err error) {
 	// Required
+	m = map[string]interface{}{}
+	m["id"] = ce.Id
+	m["source"] = ce.Source
+	m["specversion"] = ce.SpecVersion
+	m["type"] = ce.Type
+
+	// Optional
+	if len(ce.DataContentType) > 0 {
+		m["datacontenttype"] = ce.DataContentType
+	}
+	if len(ce.DataSchema) > 0 {
+		m["dataschema"] = ce.DataSchema
+	}
+	if len(ce.Subject) > 0 {
+		m["subject"] = ce.Subject
+	}
+	if !ce.Time.IsZero() {
+		m["time"] = ce.Time.Format(time.RFC3339)
+	}
+
+	// Additional
+	for k, v := range ce.Extensions {
+		m[k] = v
+	}
+
+	if len(ce.Data) > 0 {
+		// https://github.com/cloudevents/spec/blob/v1.0/json-format.md#31-handling-of-data
+		if js, err := rawJSON(ce.Data); err == nil {
+			m["data"] = js
+		} else {
+			m["data_base64"] = ce.Data
+		}
+	}
+
+	return
+}
+// FromMap converts the intermediate map representation back into a CloudEvent
+func (ce *CloudEvent) FromMap(m map[string]interface{}) (err error) {
+	// Required https://github.com/cloudevents/spec/blob/master/spec.md#required-attributes
 	ok := false
-	if ce.Id, ok = m["id"].(string); !ok {
-		return fmt.Errorf("Could not read ID as string")
+	if ce.Id, ok = m["id"].(string); !ok || len(ce.Id) <1 {
+		return fmt.Errorf(errRead("ID", "nonempty string"))
 	}
-	if ce.Source, ok = m["source"].(string); !ok {
-		return fmt.Errorf("Could not read Source as string")
+	if ce.Source, ok = m["source"].(string); !ok || len(ce.Source) <1 {
+		return fmt.Errorf(errRead("Source", "nonempty string"))
 	}
-	if ce.SpecVersion, ok = m["specversion"].(string); !ok {
-		return fmt.Errorf("Could not read Spec Version as string")
+	if ce.SpecVersion, ok = m["specversion"].(string); !ok || len(ce.Source) <1 {
+		return fmt.Errorf(errRead("Spec Version", "nonempty string"))
 	}
-	if ce.Type, ok = m["type"].(string); !ok {
-		return fmt.Errorf("Could not read Type as string")
+	if ce.Type, ok = m["type"].(string); !ok || len(ce.Type) <1 {
+		return fmt.Errorf(errRead("Type", "nonempty string"))
 	}
 
 	// Optional
 	if m["datacontenttype"] != nil {
 		if ce.DataContentType, ok = m["datacontenttype"].(string); !ok {
-			return fmt.Errorf("Could not read Data Content Type as string")
+			return fmt.Errorf(errRead("Data Content Type","string"))
 		}
 	}
 	if m["dataschema"] != nil {
 		if ce.DataSchema, ok = m["dataschema"].(string); !ok {
-			return fmt.Errorf("Could not read Data Schema as string")
+			return fmt.Errorf(errRead("Data Schema","string"))
 		}
 	}
 	if m["subject"] != nil {
 		if ce.DataSchema, ok = m["subject"].(string); !ok {
-			return fmt.Errorf("Could not read Subject as string")
+			return fmt.Errorf(errRead("Subject","string"))
 		}
 	}
 	if m["time"] != nil {
 		ceTime, ok := m["time"].(string)
 		if !ok {
-			return fmt.Errorf("Could not read Time as string")
+			return fmt.Errorf(errRead("Time","string"))
 		}
 		ce.Time, err = time.Parse(
-			time.RFC3339,//Nano
+			time.RFC3339, // allows Nano - see tests
 			ceTime)
 		if err != nil {
-			return fmt.Errorf("Could not read Time as time: %s", err.Error())
+			return fmt.Errorf("%s: %s", errRead("Time","time"), err.Error())
 		}
 	}
-
-
 	// Additional
 	ex, err := GetMapExtensions(m)
 	if err != nil {
 		return fmt.Errorf("Could not read Extensions: %s", err.Error())
 	}
-	if len(ex)>0 {
+	if len(ex) > 0 {
 		ce.Extensions = ex
 	}
 
 	if m["data_base64"] != nil {
-		if ce.Data, ok = m["data_base64"].([]byte) ; !ok {
-			return fmt.Errorf("Could not read Data Base64 as []byte")
+		if ce.Data, ok = m["data_base64"].([]byte); !ok {
+			return fmt.Errorf(errRead("Data Base64","[]byte"))
 		}
 	} else if m["data"] != nil {
-		mData, ok := m["data"].([]byte)
+		mData, ok := m["data"].(json.RawMessage)
 		if !ok {
-			return fmt.Errorf("Could not read Data as string")
+			return fmt.Errorf(errRead("Data","string"))
 		}
-		ceData, err := RawJSON(mData)
+		if len(mData) <1 {
+			return nil
+		}
+		ceData, err := rawJSON([]byte(mData))
 		if err != nil {
-			return fmt.Errorf("Could not read Data as json: %s", err.Error())
+			return fmt.Errorf("%s: %s", errRead("Data","json"), err.Error())
 		}
 		ce.Data = ceData
 	}
@@ -180,8 +218,8 @@ func (ce *CloudEvent) FromMap (m map[string]interface{}) (err error) {
 	return nil
 }
 
-
-var contextProperties = []string{
+// ContextProperties is a list of default context properties which cannot be extensions
+var ContextProperties = []string{
 	"id",
 	"source",
 	"specversion",
@@ -191,17 +229,20 @@ var contextProperties = []string{
 	"subject",
 	"time",
 	"data",
+	"data_base64",
 }
-func GetMapExtensions(m map[string]interface{}) (ex map[string]json.RawMessage, err error){
+
+// GetMapExtensions is used to extract extension properties from the intermediate map representation
+func GetMapExtensions(m map[string]interface{}) (ex map[string]json.RawMessage, err error) {
 	for k, v := range m {
-		if inSlice(k, contextProperties) {
-			continue;
+		if inSlice(k, ContextProperties) {
+			continue
 		}
 		raw, ok := v.([]byte)
 		if !ok {
-			return ex, fmt.Errorf("Could not read extension %s", k)
+			return ex, fmt.Errorf(errRead(fmt.Sprintf("extension %s", k), "[]byte"))
 		}
-		data, err := RawJSON(raw)
+		data, err := rawJSON(raw)
 		if err != nil {
 			return ex, fmt.Errorf("Could not parse extension %s: %s", k, err.Error())
 		}
@@ -209,12 +250,23 @@ func GetMapExtensions(m map[string]interface{}) (ex map[string]json.RawMessage, 
 	}
 	return
 }
+
+// inSlice is useful for checking the presence of an element in a slice
 func inSlice(e string, list []string) bool {
-    for _, v := range list {
-        if v == e {
-            return true
-        }
-    }
-    return false
+	for _, v := range list {
+		if v == e {
+			return true
+		}
+	}
+	return false
 }
 
+// rawJSON is useful for Unmarshalling json data types
+func rawJSON(data []byte) (js json.RawMessage, err error) {
+	return js, json.Unmarshal(data, &js)
+}
+
+// nonempty produces a predictable error string when needed
+func errRead(prop string, as string) string {
+	return fmt.Sprintf("Could not read %s as %s", prop, as)
+}

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Mode int
+
 const (
-        ModeBinary Mode = iota
-        ModeStructure
-        ModeBatch
+	ModeBinary Mode = iota
+	ModeStructure
+	ModeBatch
 )
 
 // CloudEvent is the primary format for events
@@ -35,6 +36,12 @@ type CloudEvent struct {
 	Data       []byte
 }
 
+// DataStruct is used for capturing certain fields conveniently from json.unmarshal
+type DataStruct struct {
+	Data   json.RawMessage `json:"data"`
+	Data64 []byte          `json:"data_base64"`
+}
+
 // Valid returns true if the CloudEvent seems to fit the spec
 func (ce CloudEvent) Valid() bool {
 	panic("Stubbed function")
@@ -49,10 +56,7 @@ func (ce CloudEvent) Valid() bool {
 // UnmarshalJSON allows translation of []byte to CloudEvent
 func (ce *CloudEvent) UnmarshalJSON(data []byte) (err error) {
 	m := map[string]interface{}{}
-	g := struct {
-		Data   json.RawMessage `json:"data"`
-		Data64 []byte          `json:"data_base64"`
-	}{}
+	g := DataStruct{}
 	if err = json.Unmarshal(data, &m); err != nil {
 		return fmt.Errorf("Could not unmarshal event: %s", err.Error())
 	}
@@ -170,8 +174,6 @@ func (ce *CloudEvent) FromMap(m map[string]interface{}) (err error) {
 
 	// Additional - Data
 	if m["data_base64"] != nil {
-		fmt.Printf("DBG:Data:%#v\n",m["data_base64"])
-
 		if ce.Data, ok = m["data_base64"].([]byte); !ok {
 			return fmt.Errorf(errRead("Data Base64", "[]byte"))
 		}
@@ -221,6 +223,7 @@ func GetMapExtensions(m map[string]interface{}) (ex map[string]interface{}, err 
 	}
 	return
 }
+
 // SetData is a utility field for setting binary data on data_base64 on a map without encoding
 func SetData(m map[string]interface{}, data []byte) {
 	// Could use some optimisation if we know len(src)

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -253,3 +253,10 @@ func TestMarshal(t *testing.T) {
 		t.Errorf("Marshal:\n%#v\n\nWant:%s\nHave:%s\n", input, want, have)
 	}
 }
+// TODO loop test
+TestLoop(t *testing.T){
+	data := `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"datacontenttype":"e","dataschema":"f","subject":"g","time":"2020-02-02T06:06:06+08:00"
+	}`
+}

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -2,107 +2,160 @@ package main
 
 import (
 	"encoding/json"
-	"testing"
 	"fmt"
+	"testing"
 )
+
 type Scenarios struct {
-	T *testing.T
-	Name string
-	Input string
-	Data CloudEvent
+	T      *testing.T
+	Name   string
+	Input  string
+	Data   CloudEvent
 	Result error
 
-	Ok func()CloudEvent
-	Err func(string)error
+	Ok  func() CloudEvent
+	Err func(string) error
 }
+
 func (s Scenarios) Failf(msg string, arg ...interface{}) {
-        s.T.Errorf("Unmarshal:%s:\n%s\n\n%s\n", s.Name, s.Input, fmt.Sprintf(msg, arg...))
+	s.T.Errorf("Unmarshal:%s:\n%s\n\n%s\n", s.Name, s.Input, fmt.Sprintf(msg, arg...))
 }
 func (s Scenarios) Logf(msg string, arg ...interface{}) {
-        s.T.Logf("Unmarshal:%s:\n\t%s\n", s.Name, fmt.Sprintf(msg, arg...))
+	s.T.Logf("Unmarshal:%s:\n\t%s\n", s.Name, fmt.Sprintf(msg, arg...))
 }
-func TestUnmarshal(t *testing.T){
-        unmarshal := func(name, data string) Scenarios {
-                ce := CloudEvent{}
+func TestUnmarshal(t *testing.T) {
+	unmarshal := func(name, data string) Scenarios {
+		ce := CloudEvent{}
 		err := ce.UnmarshalJSON([]byte(data))
-		s:= Scenarios {
-			T: t,
-			Name: name,
-			Input: data,
-			Data: ce,
+		s := Scenarios{
+			T:      t,
+			Name:   name,
+			Input:  data,
+			Data:   ce,
 			Result: err,
 		}
-		s.Ok=func()CloudEvent{
-			if err!=nil{
+		s.Ok = func() CloudEvent {
+			if err != nil {
 				s.Failf("Want no error\nHave: %s", err.Error())
 			}
 			return ce
 		}
-		s.Err=func(expect string)error{
-			if err==nil || err.Error() != expect {
-			        s.Failf("Want: %s\nHave: %s", expect, err.Error())
+		s.Err = func(expect string) error {
+			if err == nil || err.Error() != expect {
+				s.Failf("Want: %s\nHave: %s", expect, err.Error())
 			}
 			return err
 		}
 		return s
-        }
+	}
 
 	// Required
 
 	data := `{}`
-        unmarshal("Need id", data).Err(errRead("ID","nonempty string"))
+	unmarshal("Need id", data).Err(errRead("ID", "nonempty string"))
 	data = `{"id":""}`
-        unmarshal("Need id len", data).Err(errRead("ID","nonempty string"))
+	unmarshal("Need id len", data).Err(errRead("ID", "nonempty string"))
 	data = `{"id":"a"}`
-        unmarshal("Need source", data).Err(errRead("Source","nonempty string"))
+	unmarshal("Need source", data).Err(errRead("Source", "nonempty string"))
 	data = `{"id":"a","source":"b"}`
-        unmarshal("Need version", data).Err(errRead("Spec Version","nonempty string"))
+	unmarshal("Need version", data).Err(errRead("Spec Version", "nonempty string"))
 	data = `{"id":"a","source":"b","specversion":"c"}`
-        unmarshal("Need type", data).Err(errRead("Type","nonempty string"))
+	unmarshal("Need type", data).Err(errRead("Type", "nonempty string"))
 	data = `{"id":"a","source":"b","specversion":"c","type":"d"}`
-        unmarshal("Minimum", data).Ok()
+	unmarshal("Minimum", data).Ok()
 
 	// Optional
-	//
-	// Time nano vs invalid vs ms
-	//
-	// Time nano vs invalid vs ms
-	//
-	// Time nano vs invalid vs ms
-	//
-	// Time nano vs invalid vs ms
-	//
-	// Time nano vs invalid vs ms
 
 	data = `{
 		"id":"a","source":"b","specversion":"c","type":"d",
 		"datacontenttype":"e","dataschema":"f","subject":"g","time":"2020-02-02T06:06:06+08:00"
 	}`
-        unmarshal("Complete", data).Ok()
+	unmarshal("Complete", data).Ok()
 
 	data = `{
 		"id":"a","source":"b","specversion":"c","type":"d",
 		"time":"2020-02-02T06:06:06.366090001+10:00"
 	}`
-        unmarshal("NanoTime", data).Ok()
+	unmarshal("NanoTime", data).Ok()
 
 	data = `{
 		"id":"a","source":"b","specversion":"c","type":"d",
 		"time":"2020-02-02T06:06:06.366090+12:00"
 	}`
-        unmarshal("MicroTime", data).Ok()
+	unmarshal("MicroTime", data).Ok()
 
 	data = `{
 		"id":"a","source":"b","specversion":"c","type":"d",
 		"time":"2020-02-02T06:06:06.366+14:00"
 	}`
-        unmarshal("MilliTime", data).Ok()
+	unmarshal("MilliTime", data).Ok()
 
 	data = `{
 		"id":"a","source":"b","specversion":"c","type":"d",
 		"time":"2020-02-02T06:06:60+25:00"
 	}`
-        unmarshal("IvalidTime", data).Err(`Could not read Time as time: parsing time "2020-02-02T06:06:60+25:00": second out of range`)
+	unmarshal("InvalidTime", data).Err(`Could not read Time as time: parsing time "2020-02-02T06:06:60+25:00": second out of range`)
+
+	// Additional - Extensions
+
+	{ // Scoped
+		data = `{
+			"id":"a","source":"b","specversion":"c","type":"d",
+			"x":3,"y":null,"z":0.1,"a":[{}],
+			"any other string":true,
+			"extensions":"Even this"
+		}`
+		s := unmarshal("Extensions", data)
+		ex := s.Ok().Extensions
+	{
+		prop := "x"
+		want := float64(3)
+		if got, ok := ex[prop].(float64); !ok {
+			s.Failf("Want: %#v\nHave bad cast of %s with type %T\n\t%#v", want, prop, ex[prop], ex[prop])
+		} else if got != want {
+			s.Failf("Want: %#v\nHave: %#v", want, got)
+		}
+	}
+	{
+		prop := "y"
+		if ex[prop] != nil {
+			s.Failf("Have bad nil of %s\n\t%#v", prop, ex[prop])
+		}
+	}
+	{
+		prop := "z"
+		want := 0.1
+		if got, ok := ex[prop].(float64); !ok {
+			s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
+		} else if got != want {
+			s.Failf("Want: %#v\nHave: %#v", want, got)
+		}
+	}
+	{
+		prop := "a"
+		if _, ok := ex[prop].([]interface{}); !ok {
+			s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
+		}
+	}
+	{
+		prop := "any other string"
+		want := true
+		if got, ok := ex[prop].(bool); !ok {
+			s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
+		} else if got != want {
+			s.Failf("Want: %#v\nHave: %#v", want, got)
+		}
+	}
+	{
+		prop := "extensions"
+		want := "Even this"
+		if got, ok := ex[prop].(string); !ok {
+			s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
+		} else if got != want {
+			s.Failf("Want: %#v\nHave: %#v", want, got)
+		}
+	}
+	}
 
 	// Additional - JSON
 
@@ -115,10 +168,10 @@ func TestUnmarshal(t *testing.T){
 	if err != nil {
 		s.Failf("Failed to parse data: %s", err.Error())
 	}
-	if want := `{"x":[1,2,"3"]}` ; string(js) != want {
+	if want := `{"x":[1,2,"3"]}`; string(js) != want {
 		s.Failf("Want: %s\nHave: %s", want, js)
 	}
-        s.Logf("%s", js)
+	s.Logf("%s", js)
 
 	// Additional - Raw
 
@@ -131,10 +184,10 @@ func TestUnmarshal(t *testing.T){
 	if err != nil {
 		s.Failf("Failed to parse data: %s", err.Error())
 	}
-	if want := "123" ; string(js) != want {
+	if want := "123"; string(js) != want {
 		s.Failf("Want: %s\nHave: %s", want, js)
 	}
-        s.Logf("%s", js)
+	s.Logf("%s", js)
 
 	// Additional - Base64
 
@@ -144,9 +197,8 @@ func TestUnmarshal(t *testing.T){
 	}`
 	s = unmarshal("Data64", data)
 	raw := s.Ok().Data
-	if want := "hello world" ; string(raw) != want {
+	if want := "hello world"; string(raw) != want {
 		s.Failf("Want: %s\nHave: %s", want, string(raw))
 	}
-        s.Logf("%s", raw)
+	s.Logf("%s", raw)
 }
-

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -107,54 +107,54 @@ func TestUnmarshal(t *testing.T) {
 		}`
 		s := unmarshal("Extensions", data)
 		ex := s.Ok().Extensions
-	{
-		prop := "x"
-		want := float64(3)
-		if got, ok := ex[prop].(float64); !ok {
-			s.Failf("Want: %#v\nHave bad cast of %s with type %T\n\t%#v", want, prop, ex[prop], ex[prop])
-		} else if got != want {
-			s.Failf("Want: %#v\nHave: %#v", want, got)
+		{
+			prop := "x"
+			want := float64(3)
+			if got, ok := ex[prop].(float64); !ok {
+				s.Failf("Want: %#v\nHave bad cast of %s with type %T\n\t%#v", want, prop, ex[prop], ex[prop])
+			} else if got != want {
+				s.Failf("Want: %#v\nHave: %#v", want, got)
+			}
 		}
-	}
-	{
-		prop := "y"
-		if ex[prop] != nil {
-			s.Failf("Have bad nil of %s\n\t%#v", prop, ex[prop])
+		{
+			prop := "y"
+			if ex[prop] != nil {
+				s.Failf("Have bad nil of %s\n\t%#v", prop, ex[prop])
+			}
 		}
-	}
-	{
-		prop := "z"
-		want := 0.1
-		if got, ok := ex[prop].(float64); !ok {
-			s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
-		} else if got != want {
-			s.Failf("Want: %#v\nHave: %#v", want, got)
+		{
+			prop := "z"
+			want := 0.1
+			if got, ok := ex[prop].(float64); !ok {
+				s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
+			} else if got != want {
+				s.Failf("Want: %#v\nHave: %#v", want, got)
+			}
 		}
-	}
-	{
-		prop := "a"
-		if _, ok := ex[prop].([]interface{}); !ok {
-			s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
+		{
+			prop := "a"
+			if _, ok := ex[prop].([]interface{}); !ok {
+				s.Failf("Have bad cast of %s\n\t%#v", prop, ex[prop])
+			}
 		}
-	}
-	{
-		prop := "any other string"
-		want := true
-		if got, ok := ex[prop].(bool); !ok {
-			s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
-		} else if got != want {
-			s.Failf("Want: %#v\nHave: %#v", want, got)
+		{
+			prop := "any other string"
+			want := true
+			if got, ok := ex[prop].(bool); !ok {
+				s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
+			} else if got != want {
+				s.Failf("Want: %#v\nHave: %#v", want, got)
+			}
 		}
-	}
-	{
-		prop := "extensions"
-		want := "Even this"
-		if got, ok := ex[prop].(string); !ok {
-			s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
-		} else if got != want {
-			s.Failf("Want: %#v\nHave: %#v", want, got)
+		{
+			prop := "extensions"
+			want := "Even this"
+			if got, ok := ex[prop].(string); !ok {
+				s.Failf("Want: %#v\nHave bad cast of %s\n\t%#v", want, prop, ex[prop])
+			} else if got != want {
+				s.Failf("Want: %#v\nHave: %#v", want, got)
+			}
 		}
-	}
 	}
 
 	// Additional - JSON

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-type Scenarios struct {
+type Scenarios struct { // TODO: Make interface
 	T      *testing.T
 	Name   string
 	Input  string
@@ -201,4 +201,35 @@ func TestUnmarshal(t *testing.T) {
 		s.Failf("Want: %s\nHave: %s", want, string(raw))
 	}
 	s.Logf("%s", raw)
+}
+func TestMarshal(t *testing.T) {
+        input := CloudEvent{
+                Id:          "test",
+                Source:      "test",
+                SpecVersion: "test",
+                Type:        "test",
+                Data:        []byte(`{"a":2}`),
+		Extensions:  map[string]interface{}{ "hi":"test" },
+        }
+
+	// Data Normal
+	want := `{"data":{"a":2},"hi":"test","id":"test","source":"test","specversion":"test","type":"test"}`
+	js, err := input.MarshalJSON()
+	if err != nil {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nError:%s\n", input, want, err.Error())
+	}
+	if have := string(js); want != have {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nHave:%s\n", input, want, have)
+	}
+
+	// Data Base64
+	input.Data = []byte(`not "valid" json`)
+	want = `{"data_base64":"bm90ICJ2YWxpZCIganNvbg==","hi":"test","id":"test","source":"test","specversion":"test","type":"test"}`
+	js, err = input.MarshalJSON()
+	if err != nil {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nError:%s\n", input, want, err.Error())
+	}
+	if have := string(js); want != have {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nHave:%s\n", input, want, have)
+	}
 }

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"fmt"
+)
+type Scenarios struct {
+	T *testing.T
+	Name string
+	Input string
+	Data CloudEvent
+	Result error
+
+	Ok func()CloudEvent
+	Err func(string)error
+}
+func (s Scenarios) Failf(msg string, arg ...interface{}) {
+        s.T.Errorf("Unmarshal:%s:\n%s\n\n%s\n", s.Name, s.Input, fmt.Sprintf(msg, arg...))
+}
+func (s Scenarios) Logf(msg string, arg ...interface{}) {
+        s.T.Logf("Unmarshal:%s:\n\t%s\n", s.Name, fmt.Sprintf(msg, arg...))
+}
+func TestUnmarshal(t *testing.T){
+        unmarshal := func(name, data string) Scenarios {
+                ce := CloudEvent{}
+		err := ce.UnmarshalJSON([]byte(data))
+		s:= Scenarios {
+			T: t,
+			Name: name,
+			Input: data,
+			Data: ce,
+			Result: err,
+		}
+		s.Ok=func()CloudEvent{
+			if err!=nil{
+				s.Failf("Want no error\nHave: %s", err.Error())
+			}
+			return ce
+		}
+		s.Err=func(expect string)error{
+			if err==nil || err.Error() != expect {
+			        s.Failf("Want: %s\nHave: %s", expect, err.Error())
+			}
+			return err
+		}
+		return s
+        }
+
+	// Required
+
+	data := `{}`
+        unmarshal("Need id", data).Err(errRead("ID","nonempty string"))
+	data = `{"id":""}`
+        unmarshal("Need id len", data).Err(errRead("ID","nonempty string"))
+	data = `{"id":"a"}`
+        unmarshal("Need source", data).Err(errRead("Source","nonempty string"))
+	data = `{"id":"a","source":"b"}`
+        unmarshal("Need version", data).Err(errRead("Spec Version","nonempty string"))
+	data = `{"id":"a","source":"b","specversion":"c"}`
+        unmarshal("Need type", data).Err(errRead("Type","nonempty string"))
+	data = `{"id":"a","source":"b","specversion":"c","type":"d"}`
+        unmarshal("Minimum", data).Ok()
+
+	// Optional
+	//
+	// Time nano vs invalid vs ms
+	//
+	// Time nano vs invalid vs ms
+	//
+	// Time nano vs invalid vs ms
+	//
+	// Time nano vs invalid vs ms
+	//
+	// Time nano vs invalid vs ms
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"datacontenttype":"e","dataschema":"f","subject":"g","time":"2020-02-02T06:06:06+08:00"
+	}`
+        unmarshal("Complete", data).Ok()
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"time":"2020-02-02T06:06:06.366090001+10:00"
+	}`
+        unmarshal("NanoTime", data).Ok()
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"time":"2020-02-02T06:06:06.366090+12:00"
+	}`
+        unmarshal("MicroTime", data).Ok()
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"time":"2020-02-02T06:06:06.366+14:00"
+	}`
+        unmarshal("MilliTime", data).Ok()
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"time":"2020-02-02T06:06:60+25:00"
+	}`
+        unmarshal("IvalidTime", data).Err(`Could not read Time as time: parsing time "2020-02-02T06:06:60+25:00": second out of range`)
+
+	// Additional - JSON
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"data":{"x":[1,2,"3"]}
+	}`
+	s := unmarshal("DataJSON", data)
+	js, err := json.RawMessage(s.Ok().Data).MarshalJSON()
+	if err != nil {
+		s.Failf("Failed to parse data: %s", err.Error())
+	}
+	if want := `{"x":[1,2,"3"]}` ; string(js) != want {
+		s.Failf("Want: %s\nHave: %s", want, js)
+	}
+        s.Logf("%s", js)
+
+	// Additional - Raw
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"data":123
+	}`
+	s = unmarshal("DataInt", data)
+	js, err = json.RawMessage(s.Ok().Data).MarshalJSON()
+	if err != nil {
+		s.Failf("Failed to parse data: %s", err.Error())
+	}
+	if want := "123" ; string(js) != want {
+		s.Failf("Want: %s\nHave: %s", want, js)
+	}
+        s.Logf("%s", js)
+
+	// Additional - Base64
+
+	data = `{
+		"id":"a","source":"b","specversion":"c","type":"d",
+		"data_base64":"aGVsbG8gd29ybGQ="
+	}`
+	s = unmarshal("Data64", data)
+	raw := s.Ok().Data
+	if want := "hello world" ; string(raw) != want {
+		s.Failf("Want: %s\nHave: %s", want, string(raw))
+	}
+        s.Logf("%s", raw)
+}
+

--- a/jsonce/jsonce_test.go
+++ b/jsonce/jsonce_test.go
@@ -1,8 +1,9 @@
-package main
+package jsonce
 
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 	"testing"
 )
 
@@ -225,6 +226,25 @@ func TestMarshal(t *testing.T) {
 	// Data Base64
 	input.Data = []byte(`not "valid" json`)
 	want = `{"data_base64":"bm90ICJ2YWxpZCIganNvbg==","hi":"test","id":"test","source":"test","specversion":"test","type":"test"}`
+	js, err = input.MarshalJSON()
+	if err != nil {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nError:%s\n", input, want, err.Error())
+	}
+	if have := string(js); want != have {
+		t.Errorf("Marshal:\n%#v\n\nWant:%s\nHave:%s\n", input, want, have)
+	}
+
+	// All fields
+	input.Data = []byte(`x`)
+	input.DataContentType = "a"
+	input.DataSchema = "b"
+	input.Subject = "c"
+	input.Time, err = time.Parse(time.RFC3339, "2020-02-02T06:06:06Z")
+	if err != nil {
+		t.Errorf("Test error parsing time: %s", err.Error())
+	}
+
+	want = `{"data_base64":"eA==","datacontenttype":"a","dataschema":"b","hi":"test","id":"test","source":"test","specversion":"test","subject":"c","time":"2020-02-02T06:06:06Z","type":"test"}`
 	js, err = input.MarshalJSON()
 	if err != nil {
 		t.Errorf("Marshal:\n%#v\n\nWant:%s\nError:%s\n", input, want, err.Error())

--- a/main.go
+++ b/main.go
@@ -2,40 +2,8 @@ package main
 
 import (
 	"github.com/creativecactus/fast-cloudevents-go/fastce"
-
-	"encoding/json"
-	"log"
-	"net/http"
-
-	"github.com/valyala/fasthttp"
 )
 
 func main() {
-	ExampleServer()
-}
-
-// ExampleServer shows an example implementation of each method with a fasthttp server.
-func ExampleServer() {
-	listenAddr := "0.0.0.0:8080"
-	requestHandler := func(ctx *fasthttp.RequestCtx) {
-		event, err := fastce.FastHTTPToEventBinary(ctx)
-		if err != nil {
-			ctx.Error(err.Error(), http.StatusBadRequest)
-			return
-		}
-		js, err := json.Marshal(event)
-		if err != nil {
-			ctx.Error("Could not marshal", http.StatusInternalServerError)
-			return
-		}
-		log.Printf("%s\n", string(js))
-		if err = json.Unmarshal(js, &event); err != nil {
-			ctx.Error("Could not unmarshal", http.StatusInternalServerError)
-			return
-		}
-		fastce.EventToFastHTTPBinary(event)(ctx) //fmt.Fprintf(ctx, "%q", ctx.Path())
-	}
-	if err := fasthttp.ListenAndServe(listenAddr, requestHandler); err != nil {
-		log.Fatalf("Error in ListenAndServe: %s", err)
-	}
+	fastce.ExampleServer("0.0.0.0:8080")
 }

--- a/main.go
+++ b/main.go
@@ -1,9 +1,49 @@
 package main
 
 import (
+	"log"
+	"net/http"
+	
+	"github.com/valyala/fasthttp"
+
 	"github.com/creativecactus/fast-cloudevents-go/fastce"
 )
 
 func main() {
-	fastce.ExampleServer("0.0.0.0:8080")
+	ExampleServer("0.0.0.0:8080")
+}
+
+/*
+ ███████╗███████╗██████╗ ██╗   ██╗███████╗██████╗
+ ██╔════╝██╔════╝██╔══██╗██║   ██║██╔════╝██╔══██╗
+ ███████╗█████╗  ██████╔╝██║   ██║█████╗  ██████╔╝
+ ╚════██║██╔══╝  ██╔══██╗╚██╗ ██╔╝██╔══╝  ██╔══██╗
+ ███████║███████╗██║  ██║ ╚████╔╝ ███████╗██║  ██║
+ ╚══════╝╚══════╝╚═╝  ╚═╝  ╚═══╝  ╚══════╝╚═╝  ╚═╝
+*/
+
+// ExampleServer shows an example implementation of each method with a fasthttp server.
+func ExampleServer(listenAddr string) {
+	router := func(ctx *fasthttp.RequestCtx) {
+		switch p := string(ctx.Path()); p {
+		case "/debug":
+			ctx.Write([]byte("Hello World"))
+			break
+		default:
+			ces, mode, err := fastce.GetEvents(ctx)
+			if err != nil {
+				log.Printf("ERR: %s", err.Error())
+				ctx.Error(err.Error(), http.StatusBadRequest)
+				return
+			} else {
+				log.Printf("OK : Received %d events in mode %d\n", len(ces), mode)
+			}
+			log.Printf("\tData: %#v\n", ces)
+			fastce.PutEvents(ctx, ces, mode)
+		}
+	}
+	log.Printf("Listening on %s", listenAddr)
+	if err := fasthttp.ListenAndServe(listenAddr, router); err != nil {
+		log.Fatalf("Error in ListenAndServe: %s", err)
+	}
 }

--- a/task
+++ b/task
@@ -1,3 +1,12 @@
+unit(){ ## Unit tests
+	docker(){ ## Run inside docker
+		dgo go test --cover -v
+	}
+	default(){ ## Run locally
+		go test --cover -v
+	}
+	"${@:-default}"
+}
 run(){ ## Start server locally
 	docker(){ ## Run server in docker
 		## See https://gist.github.com/CreativeCactus/c08b8d3bc45da84d50cd828660f134d0

--- a/task
+++ b/task
@@ -9,15 +9,43 @@ run(){ ## Start server locally
 	"${@:-deault}"
 }
 test(){ ## Curl tests
-	curl -v -X POST \
-		-H "Content-Type: application/cloudevents+json" \
-		-H "ce-type: com.example.someevent" \
-		-H "ce-time: $(date '+%FT%T.%N%:z')" \
-		-H "ce-id: $(uuidgen)" \
-		-H "ce-source: a/b/" \
-		-H "ce-specversion: 1.0" \
-		-H "ce-myextension: 1234" \
-		-d @<(echo '{"hello":"world"}') \
-		http://localhost:8080/
+	root(){ ## Root path
+		curl -v -X GET http://localhost:8080/
+	}
+	structured(){ ## Structured mode
+		curl -v -X POST \
+			-H "Content-Type: application/cloudevents+json" \
+			-d @<(echo '{
+				"type": "com.example.someevent",
+				"time": "'$(date '+%FT%T.%N%:z')'",
+				"id": "'$(uuidgen)'",
+				"source": "a/b/",
+				"specversion": "1.0",
+				"myextension": 1234,
+				"data":{"hello":"world"}
+			}' | jq -rc '.' ) \
+			http://localhost:8080/structured
+	}
+	binary(){ ## Binary mode
+		curl -v -X POST \
+			-H "Content-Type: application/cloudevents+json" \
+			-H "ce-type: com.example.someevent" \
+			-H "ce-time: $(date '+%FT%T.%N%:z')" \
+			-H "ce-id: $(uuidgen)" \
+			-H "ce-source: a/b/" \
+			-H "ce-specversion: 1.0" \
+			-H "ce-myextension: 1234" \
+			-d @<(echo '{"hello":"world"}') \
+			http://localhost:8080/binary
+	}
+	all(){ ## Run each test
+		echo "#####################################"
+		root
+		echo "#####################################"
+		structured
+		echo "#####################################"
+		binary
+	}
+	"${@:-all}"
 }
 "${@:-test}"

--- a/task
+++ b/task
@@ -18,11 +18,11 @@ run(){ ## Start server locally
 	"${@:-deault}"
 }
 test(){ ## Curl tests
-	root(){ ## Root path
-		curl -v -X GET http://localhost:8080/
+	debug(){ ## Debug path
+		curl -X GET http://localhost:8080/debug
 	}
 	structured(){ ## Structured mode
-		curl -v -X POST \
+		curl -v \
 			-H "Content-Type: application/cloudevents+json" \
 			-d @<(echo '{
 				"type": "com.example.someevent",
@@ -36,8 +36,7 @@ test(){ ## Curl tests
 			http://localhost:8080/structured
 	}
 	binary(){ ## Binary mode
-		curl -v -X POST \
-			-H "Content-Type: application/cloudevents+json" \
+		curl -v \
 			-H "ce-type: com.example.someevent" \
 			-H "ce-time: $(date '+%FT%T.%N%:z')" \
 			-H "ce-id: $(uuidgen)" \
@@ -48,12 +47,14 @@ test(){ ## Curl tests
 			http://localhost:8080/binary
 	}
 	all(){ ## Run each test
-		echo "#####################################"
-		root
-		echo "#####################################"
+		echo ; echo "#####################################" ; echo
+		debug
+		echo ; echo "#####################################" ; echo
 		structured
-		echo "#####################################"
+		echo ; echo "#####################################" ; echo
 		binary
+		echo ; echo "#####################################" ; echo
+
 	}
 	"${@:-all}"
 }


### PR DESCRIPTION
An initial, feature complete implementation of **Binary** and **Structured JSON** content modes for `fasthttp`. Not guaranteed to be perfectly compliant, but tests show this version to be fast, stable and secure. Some use of `interface{}` on headers, which might trip some newer developers up.

**Batched** mode support is a work in progress.
`net/http` support is a low priority.
No plans to implement other structured types, but they can be easily extended.
