### PR TITLE
Lenient unmashal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
-module github.com/creativecactus/fast-cloudevents-go
+module github.com/elhedran/fast-cloudevents-go
 
 go 1.13
 
-require github.com/valyala/fasthttp v1.8.0
+require (
+	github.com/creativecactus/fast-cloudevents-go v0.2.4
+	github.com/valyala/fasthttp v1.8.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
-module github.com/elhedran/fast-cloudevents-go
+module github.com/creativecactus/fast-cloudevents-go
 
 go 1.13
 
-require (
-	github.com/creativecactus/fast-cloudevents-go v0.2.4
-	github.com/valyala/fasthttp v1.8.0
-)
+require github.com/valyala/fasthttp v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/creativecactus/fast-cloudevents-go v0.2.4 h1:AYZhoMsbwvyx/v933LJuNm8QQPeXW94UugzmmqHDQXQ=
+github.com/creativecactus/fast-cloudevents-go v0.2.4/go.mod h1:P4fFqPoYrs0WTSTpdjt3nX2jYKFklfPC+9CoN+eSeOc=
 github.com/klauspost/compress v1.8.2 h1:Bx0qjetmNjdFXASH02NSAREKpiaDwkO1DRZ3dV2KCcs=
 github.com/klauspost/compress v1.8.2/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.1 h1:vJi+O/nMdFt0vqm8NZBI6wzALWdA2X+egi0ogNyrC/w=

--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -400,22 +400,31 @@ func DefaultMapToCE(m CEMap) (ce CloudEvent, err error) {
 	fmt.Sprintf("DefaultMapToCE: %#v\n", m)
 	ce = CloudEvent{}
 	// Required https://github.com/cloudevents/spec/blob/master/spec.md#required-attributes
+	// These are enforced as required in .Valid()
 	ok := false
-	if ce.Id, ok = m["id"].(string); !ok || len(ce.Id) < 1 {
-		err = fmt.Errorf(errRead("ID", "nonempty string"))
-		return
+	if m["id"] != nil {
+		if ce.Id, ok = m["id"].(string); !ok {
+			err = fmt.Errorf(errRead("ID", "string"))
+			return
+		}
 	}
-	if ce.Source, ok = m["source"].(string); !ok || len(ce.Source) < 1 {
-		err = fmt.Errorf(errRead("Source", "nonempty string"))
-		return
+	if m["source"] != nil {
+		if ce.Source, ok = m["source"].(string); !ok {
+			err = fmt.Errorf(errRead("Source", "string"))
+			return
+		}
 	}
-	if ce.SpecVersion, ok = m["specversion"].(string); !ok || len(ce.Source) < 1 {
-		err = fmt.Errorf(errRead("Spec Version", "nonempty string"))
-		return
+	if m["specversion"] != nil {
+		if ce.SpecVersion, ok = m["specversion"].(string); !ok {
+			err = fmt.Errorf(errRead("Spec Version", "string"))
+			return
+		}
 	}
-	if ce.Type, ok = m["type"].(string); !ok || len(ce.Type) < 1 {
-		err = fmt.Errorf(errRead("Type", "nonempty string"))
-		return
+	if m["type"] != nil {
+		if ce.Type, ok = m["type"].(string); !ok {
+			err = fmt.Errorf(errRead("Type", "string"))
+			return
+		}
 	}
 
 	// Optional


### PR DESCRIPTION
The Unmarshaller interface for cloud events
should be lenient in terms of required fields, but not field types.

This allows a wider range of usage including fixing events
between parsing and use, without requiring a CE map, as well
as combingin multiple JSON inputs for a single event.

Can still validate cloud events if required using .Valid function,
as demonstrated by testing.

This separates out the responsibility of parsing a cloud event from validating one more cleanly, and allows much cleaner code for usages which require a partial cloud event parse.