### PR TITLE
Fix jsonce.GenerateValidEvents specversion

### DIFF
--- a/jsonce/jsonce.go
+++ b/jsonce/jsonce.go
@@ -555,7 +555,7 @@ func GenerateValidEvents(num uint) []CloudEvent {
 		ces = append(ces, CloudEvent{
 			Id:              uuid.New().String(),
 			Source:          "Example",
-			SpecVersion:     "v1.0",
+			SpecVersion:     "1.0",
 			Type:            "test",
 			DataSchema:      "http://localhost/schema",
 			Subject:         "test",


### PR DESCRIPTION
"v1.0" is not a valid reference to a CloudEvents specversion, it should
instead be "1.0", see the [v1.0 specification documentation](https://github.com/cloudevents/spec/blob/v1.0/spec.md#specversion)